### PR TITLE
Adding rollers for coriolis and 1e 7th sea

### DIFF
--- a/coriolis_roller.html
+++ b/coriolis_roller.html
@@ -1,0 +1,57 @@
+<html>
+	<head>
+		<script>
+			// This will roll a number of d6 at any denomination and return the number of sixes rolled.
+			function simpleRoll() {
+				const numDice = document.getElementById('diceroll').value; // Grab value
+				const rollArray = [];
+				let numSixes = 0;
+
+				for (i = 0; i < numDice; i++) {
+					// Get decimal, multiply by denomination and round down, and one so the range doesn't start at zero
+					const roll = Math.floor(Math.random() * 6) + 1;
+					if (roll === 6){
+						numSixes += 1;
+					} else {
+						rollArray.push(roll);
+					}
+				}
+
+				let rollText = "";
+				if (numSixes >= 3){
+					rollText = "<span style=\"color:red;\"><strong>Critical Success! </strong></span>"
+				}
+
+				// Bold the successful rolls
+				let successText = numSixes + " Success(es) [";
+				for (i = 0; i < numSixes; i++) {
+					successText += '<strong>6</strong>, ';
+				}
+
+				// Sort in descending order and add a space between each value
+				let failureArray = rollArray.sort(function (a, b) { return b - a}).join(", ");
+
+				document.getElementById("results").innerHTML += '<p>' + rollText + successText + failureArray + ']</p>';
+			}
+
+			function clearRoll() {
+				document.getElementById("results").innerHTML = '';
+			}
+		</script>
+
+	</head>
+
+	<body>
+
+		Enter the number of dice in your pool
+		<form onsubmit="return false;">
+			<input type="text" id="diceroll" onkeydown = "if (event.keyCode === 13)
+                        {simpleRoll()}"><br>
+			<button type="button" onclick="simpleRoll()">Roll!</button>
+			<button type="button" onclick="clearRoll()">Clear Roll History</button>
+		</form>
+		<div id='error'></div>
+		<div id='results'></div>
+	</body>
+
+</html>

--- a/seventh_sea_1e_roller.html
+++ b/seventh_sea_1e_roller.html
@@ -1,0 +1,108 @@
+<html lang="en">
+	<head>
+		<title>7th Sea 1e Roller</title>
+		<script>
+		//
+			function poolRoll() {
+				const rollCount = Number(document.getElementById('dice_roll').value);
+				const keepCount = Number(document.getElementById('dice_keep').value);
+				document.getElementById("error").innerHTML = '';
+
+				if (rollCount >= keepCount){
+					let numTens = 0;
+					const rollArray = [];
+
+					for (let i = 0; i < rollCount; i++) {
+						// Get decimal, multiply by 10 and round down, add one so the range doesn't start at zero
+						const roll = Math.floor(Math.random() * 10) + 1;
+						if (roll === 10){
+							numTens += 1;
+						}
+						rollArray.push(roll);
+					}
+
+					let totalExplodingDice = 0;
+					let explodingDiceValue = 0;
+					const explodingRollArray = [];
+
+					if (keepCount >= numTens) {
+						for (let i = 0; i < numTens; i++) {
+							// Get decimal, multiply by 10 and round down, add one so the range doesn't start at zero
+							let rollExploding = Math.floor(Math.random() * 10) + 1;
+							totalExplodingDice += 1
+							explodingDiceValue += rollExploding
+							explodingRollArray.push(rollExploding);
+							while (rollExploding === 10) {
+								totalExplodingDice += 1
+								explodingDiceValue += rollExploding
+								explodingRollArray.push(rollExploding);
+								rollExploding = Math.floor(Math.random() * 10) + 1;
+							}
+						}
+					} else {
+						// TODO: If more tens are rolled then there are kept dice we should roll explosions for every
+						// TODO: 10, then only keep the number of kept dice. See github issues for an example
+						document.getElementById("results").innerHTML += "<p style=\"color:red;\">You need to roll the exploding dice separately</p>";
+					}
+
+					const orderedRollArray = rollArray.sort(function (a, b) {
+						return b - a
+					});
+
+					let keepValueArray = orderedRollArray.slice(0, keepCount)
+					const successes = keepValueArray.reduce((a,b)=>a+b) + explodingDiceValue;
+
+					// Bold the successful rolls
+					let rollText = successes + " [";
+					keepValueArray.forEach((keep) => rollText += "<strong>" + keep + "</strong>, ");
+
+					// Show unkept dice
+					rollText += orderedRollArray.slice(keepCount).join(", ") + "]"
+
+					// If dice exploded, show the added values and how many explosions occured
+					if (numTens > 0) {
+						rollText += " <span style=\"color:red;\"><strong>You rolled "
+								+ numTens
+								+ " exploding dice! </strong>("
+								+ explodingRollArray.join(", ")
+								+ ")</span>";
+					}
+
+					document.getElementById("results").innerHTML += "<p>" + rollText + "</p>";
+
+			} else {
+				document.getElementById("error").innerHTML = "Can't keep more dice than you roll!";
+			}
+		}
+
+			function clearRoll() {
+				document.getElementById("results").innerHTML = '';
+				document.getElementById("error").innerHTML = '';
+			}
+		</script>
+
+		<style>
+			#error
+				{
+				    color: red;
+				}
+		</style>
+
+	</head>
+
+	<body>
+
+<!--		For roll/keep systems enter the number of d10 you want to roll separated by a space and the number of dice to keep. <br/>-->
+<!--		Ex: To roll 3 d6, 4 d8, and 1d12, keeping the highest two rolls enter "3d6 4d8 1d12 k2"<br/><br/>-->
+		<form onsubmit="return false;">
+			<label for="dice_roll">Number of Dice to Roll: </label><input type="text" id="dice_roll" onkeydown = "if (event.keyCode === 13) {poolRoll()}"><br>
+			<label for="dice_keep">Number of Dice to Keep: </label><input type="text" id="dice_keep" onkeydown = "if (event.keyCode === 13) {poolRoll()}"><br>
+<!--			<label for="special_dice">Number of Special Dice: </label><input type="text" id="special_dice" onkeydown = "if (event.keyCode === 13) {poolRoll()}"><br>-->
+			<button type="button" onclick="poolRoll()">Roll!</button>
+			<button type="button" onclick="clearRoll()">Clear Roll History</button>
+		</form>
+		<div id='error'></div>
+		<div id='results'></div>
+	</body>
+
+</html>


### PR DESCRIPTION
### Coriolis dice system:
- Roll a pool of d6
- Each 6 is a success
- 3+ successes is a critical success
- There are no crit fails

### 7th Sea 1e dice system
- Roll a pool of d10
- Keep a set amount of dice. Notation is _k_, so rolling five dice and keeping two results would be 5k2
- 10s explode, meaning they are rerolled and added to the total past the normal keep limit. A 5k2 roll of [10, 9, 4, 3, 3] would be 19 **+** another d10 roll. If the next roll is also a 10 you roll again until you get a non-10 number. Continuing this example if I roll a 10 on my exploding dice, I roll again, getting a 3. This breaks the streak, but I add 13 to my original total of 19, earning me a 32. 
- The code doesn't currently account for situations like when more tens are rolled then there are kept dice. See https://github.com/mjtolentino/accessible_dice/issues/2